### PR TITLE
rename output package with hyphen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-About geoh5_interop-feedstock
+About geoh5-interop-feedstock
 =============================
 
 Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/geoh5_interop-feedstock/blob/main/LICENSE.txt)
@@ -34,53 +34,53 @@ Current release info
 
 | Name | Downloads | Version | Platforms |
 | --- | --- | --- | --- |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-geoh5_interop-green.svg)](https://anaconda.org/conda-forge/geoh5_interop) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/geoh5_interop.svg)](https://anaconda.org/conda-forge/geoh5_interop) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/geoh5_interop.svg)](https://anaconda.org/conda-forge/geoh5_interop) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/geoh5_interop.svg)](https://anaconda.org/conda-forge/geoh5_interop) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-geoh5--interop-green.svg)](https://anaconda.org/conda-forge/geoh5-interop) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/geoh5-interop.svg)](https://anaconda.org/conda-forge/geoh5-interop) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/geoh5-interop.svg)](https://anaconda.org/conda-forge/geoh5-interop) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/geoh5-interop.svg)](https://anaconda.org/conda-forge/geoh5-interop) |
 
-Installing geoh5_interop
+Installing geoh5-interop
 ========================
 
-Installing `geoh5_interop` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `geoh5-interop` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `geoh5_interop` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `geoh5-interop` can be installed with `conda`:
 
 ```
-conda install geoh5_interop
-```
-
-or with `mamba`:
-
-```
-mamba install geoh5_interop
-```
-
-It is possible to list all of the versions of `geoh5_interop` available on your platform with `conda`:
-
-```
-conda search geoh5_interop --channel conda-forge
+conda install geoh5-interop
 ```
 
 or with `mamba`:
 
 ```
-mamba search geoh5_interop --channel conda-forge
+mamba install geoh5-interop
+```
+
+It is possible to list all of the versions of `geoh5-interop` available on your platform with `conda`:
+
+```
+conda search geoh5-interop --channel conda-forge
+```
+
+or with `mamba`:
+
+```
+mamba search geoh5-interop --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search geoh5_interop --channel conda-forge
+mamba repoquery search geoh5-interop --channel conda-forge
 
-# List packages depending on `geoh5_interop`:
-mamba repoquery whoneeds geoh5_interop --channel conda-forge
+# List packages depending on `geoh5-interop`:
+mamba repoquery whoneeds geoh5-interop --channel conda-forge
 
-# List dependencies of `geoh5_interop`:
-mamba repoquery depends geoh5_interop --channel conda-forge
+# List dependencies of `geoh5-interop`:
+mamba repoquery depends geoh5-interop --channel conda-forge
 ```
 
 
@@ -125,17 +125,17 @@ Terminology
                   produce the finished article (built conda distributions)
 
 
-Updating geoh5_interop-feedstock
+Updating geoh5-interop-feedstock
 ================================
 
-If you would like to improve the geoh5_interop recipe or build a new
+If you would like to improve the geoh5-interop recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/geoh5_interop-feedstock are
+Note that all branches in the conda-forge/geoh5-interop-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -14,7 +14,7 @@ source:
 build:
   noarch: python
   script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
 
 requirements:
   host:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -4,7 +4,7 @@ context:
   python_min: 3.10
 
 package:
-  name: ${{ name|lower }}
+  name: ${{ name|lower|replace('_', '-') }}
   version: ${{ version }}
 
 source:


### PR DESCRIPTION
rename geoh5_interop to geoh5-interop
according to the naming convention used for other packages

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
